### PR TITLE
chore: change to non-free license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,116 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        Aspect Community License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+BY DOWNLOADING, COPYING, OR OTHERWISE USING THE SOFTWARE WITH WHICH THIS LICENSE AGREEMENT IS
+PROVIDED (THE “SOFTWARE”), YOU OR THE ENTITY YOU REPRESENT (“LICENSEE”) ARE CONSENTING TO BE BOUND
+BY AND ARE BECOMING A PARTY TO THIS LICENSE AGREEMENT (“AGREEMENT”).
 
-   1. Definitions.
+IF YOU DO NOT AGREE TO ALL OF THE TERMS OF THIS AGREEMENT, THEN YOU MAY NOT DOWNLOAD THE SOFTWARE
+AND MUST DELETE ANY COPIES THAT YOU HAVE ALREADY DOWNLOADED.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+IF LICENSEE IS AN ENTITY, YOU REPRESENT AND WARRANT THAT YOU ARE AUTHORIZED TO BIND LICENSEE.
+IF THESE TERMS ARE CONSIDERED AN OFFER, ACCEPTANCE IS EXPRESSLY LIMITED TO THESE TERMS.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+1.	Grant.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+    Subject to the terms of this Agreement, Aspect Build Systems, Inc. (“Aspect”)
+    hereby grants Licensee (and only Licensee) a limited, non-sublicensable, non-transferable,
+    royalty-free, nonexclusive license to use the Software only in Licensee’s organization and only
+    in accordance with any documentation that accompanies it.
+    
+    The Software may only be used by a Licensee who is:
+    (i)   an individual (and only for personal use),
+    (ii)  a Small Business (as defined below),
+    (iii) a non-profit entity or an academic or university institution, or
+    (iv)  an Aspect Customer (as defined below).
+    
+    A “Small Business” is any entity with fewer than 50 total employees (including, for purposes
+    of such calculation, all employees of any entities affiliated with such entity).
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+    An “Aspect Customer” is any entity that has remitted payment to Aspect.
+    Such payment may be for professional services such as Bazel OSS support, for software licensing
+    and maintenence such as Aspect Workflows, or for other products or services sold by Aspect.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+2.	Restrictions.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+    Licensee may not, directly or indirectly:
+    (i) copy, distribute, rent, lease, timeshare, operate a service bureau with, use commercially
+    or for the benefit of a third party, the Software,
+    (ii) reverse engineer, disassemble, decompile, attempt to discover the source code or
+    structure, sequence and organization of, or remove any proprietary notices from, any non-source
+    forms of the Software.
+    
+    As between the parties, title, ownership rights, and intellectual property rights in and to the
+    Software, and any copies or portions thereof, shall remain in Aspect and its suppliers or
+    licensors. Licensee understands that Aspect may modify or discontinue offering the
+    Software at any time. The Software is protected by the copyright laws of the United States and
+    international copyright treaties.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+    This Agreement does not grant any rights not expressly granted herein.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+3. 	Feedback.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+    Licensee may provide any feedback, suggestions, or comments to Aspect
+    regarding the Software (“Feedback”). Licensee hereby grants Aspect a nonexclusive,
+    perpetual, worldwide, royalty-free, fully paid-up, sublicensable, transferable license to use,
+    make available and otherwise exploit the Feedback for any purpose.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+4.	Support and Upgrades.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+    This Agreement does not entitle Licensee to any support, upgrades,
+    patches, enhancements, or fixes for the Software (collectively, “Support”).
+    Any such Support for the Software that may be made available by Aspect shall become
+    part of the Software and subject to this Agreement.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+5.	Disclaimer.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+    ASPECT PROVIDES THE SOFTWARE “AS IS” AND WITHOUT WARRANTY OF ANY KIND, AND
+    ASPECT HEREBY DISCLAIMS ALL EXPRESS OR IMPLIED WARRANTIES, INCLUDING WITHOUT LIMITATION
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, PERFORMANCE, ACCURACY,
+    RELIABILITY, AND NON-INFRINGEMENT. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF
+    THIS AGREEMENT.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+6.	Limitation of liability.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+    UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, INCLUDING, WITHOUT
+    LIMITATION, TORT, CONTRACT, STRICT LIABILITY, OR OTHERWISE, SHALL ASPECT OR ITS
+    LICENSORS, SUPPLIERS OR RESELLERS BE LIABLE TO LICENSEE OR ANY OTHER PERSON FOR ANY DIRECT,
+    INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+    LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK STOPPAGE, ACCURACY OF RESULTS,
+    COMPUTER FAILURE OR MALFUNCTION, DAMAGES RESULTING FROM LICENSEE’S USE OF THE SOFTWARE.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+7.	Termination.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+    Licensee may terminate this Agreement and the license granted herein at any time
+    by destroying or removing from all computers, networks, and storage media all copies of the
+    Software. Aspect may terminate this Agreement and the license granted herein immediately
+    if Licensee breaches any provision of this Agreement. Upon receiving notice of termination from
+    Aspect, Licensee will destroy or remove from all computers, networks, and storage media
+    all copies of the Software. Sections 2 through 9 shall survive termination of this Agreement.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+8.	Export Controls.
+    
+    Licensee shall comply with all export laws and restrictions and regulations of
+    the Department of Commerce, the United States Department of Treasury Office of Foreign Assets
+    Control (“OFAC”), or other United States or foreign agency or authority, and not to export, or
+    allow the export or re-export of the Software in violation of any such restrictions, laws or
+    regulations. By downloading or using the Software, Licensee is agreeing to the foregoing and
+    Licensee is representing and warranting that Licensee is not located in, under the control of,
+    or a national or resident of any restricted country or on any such list.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+9.	Miscellaneous.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+    Licensee shall comply with all applicable export laws, restrictions and
+    regulations in connection with Licensee’s use of the Software, and will not export or
+    re-export the Software in violation thereof. This Agreement is personal to Licensee and
+    Licensee shall not assign or transfer the Agreement or the Software to any third party under
+    any circumstances.
+    
+    This Agreement represents the complete agreement concerning this license
+    between the parties and supersedes all prior agreements and representations between them.
+    It may be amended only by a writing executed by both parties.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+    If any provision of this Agreement is held to be unenforceable for any reason, such provision
+    shall be reformed only to the extent necessary to make it enforceable.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+    This Agreement shall be governed by and construed under California law as such law applies to
+    agreements between California residents entered into and to be performed within California.


### PR DESCRIPTION
Unlike our bazel-lib library, which is needed pretty much everywhere in the Bazel ecosystem, and unlike rules_js, which most Bazel users require just to get started, rules_aws is a 'last mile' integration for larger organizations. Therefore we aren't obligated to provide it for free, and we can fund development and maintenance of this from our paying customer base.
