### PR TITLE
chore: disable Windows platform usage and add better warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,5 +29,5 @@ jobs:
           {"folder": ".", "bzlmodEnabled": false},
           {"bazelversion": "5.4.0", "bzlmodEnabled": true},
           {"bazelversion": "5.4.0", "os": "macos-latest"},
-          {"bazelversion": "5.4.0", "os": "windows-latest"},
         ]
+      exclude_windows: true

--- a/aws/private/toolchains_repo.bzl
+++ b/aws/private/toolchains_repo.bzl
@@ -39,7 +39,7 @@ PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
     ),
-    "win32": struct(
+    "windows": struct(
         compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",


### PR DESCRIPTION
The Windows distribution for AWS CLI is bundled using a .msi file.
This requires special handling for unpacking, which we are not
prepared to handle/test/maintain at the moment. So instead, alert
users, point them to an issue they can +1, and in the meantime
disable CI testing for Windows so we can stay green.

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)
- New feature or functionality (change which adds functionality)
- Style (white-space, formatting, etc...)
- Refactor (a code change that neither fixes a bug or adds a new feature)
- Performance (a code change that improves performance)
- Documentation (updates to documentation or READMEs)
- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Relevant documentation has been updated
- Suggested release notes are provided below:

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
