### PR TITLE
feat: s3_sync rule for continuous delivery

### DIFF
--- a/aws/BUILD.bazel
+++ b/aws/BUILD.bazel
@@ -45,6 +45,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//aws/private:py_lambda",
+        "//aws/private:s3_sync",
         "@rules_oci//oci:defs",
         "@rules_python//python:defs_bzl",
     ],

--- a/aws/defs.bzl
+++ b/aws/defs.bzl
@@ -3,6 +3,9 @@
 load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//aws/private:py_lambda.bzl", "py_lambda_tars")
+load("//aws/private:s3_sync.bzl", _s3_sync = "s3_sync")
+
+s3_sync = _s3_sync
 
 def aws_py_lambda(name, entry_point = "lambda_function.py", deps = [], base = "@aws_lambda_python"):
     """Defines a Lambda run on the Python runtime.

--- a/aws/private/BUILD.bazel
+++ b/aws/private/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+exports_files(["s3_sync.sh"])
+
 bzl_library(
     name = "toolchains_repo",
     srcs = ["toolchains_repo.bzl"],
@@ -24,5 +26,11 @@ bzl_library(
         "py_lambda.bzl",
         "@rules_pkg//pkg:bzl_srcs",
     ],
+    visibility = ["//aws:__subpackages__"],
+)
+
+bzl_library(
+    name = "s3_sync",
+    srcs = ["s3_sync.bzl"],
     visibility = ["//aws:__subpackages__"],
 )

--- a/aws/private/s3_sync.bzl
+++ b/aws/private/s3_sync.bzl
@@ -1,0 +1,52 @@
+"Executable rule to release artifacts to an S3 bucket"
+
+_DOC = """\
+Executable rule to copy or sync files to an S3 bucket.
+
+Intended for use with `bazel run`, and with Aspect's Continuous Delivery feature.
+"""
+
+_ATTRS = {
+    "srcs": attr.label_list(
+        doc = "Files to copy to the s3 bucket",
+        allow_files = True,
+        mandatory = True,
+    ),
+    "bucket": attr.label(
+        doc = "file containing a single line: the S3 bucket to copy to",
+        allow_single_file = True,
+        mandatory = True,
+    ),
+    "aws": attr.label(
+        doc = "AWS CLI",
+        default = Label("@aws"),
+    ),
+    "_sync_script": attr.label(
+        default = Label("//aws/private:s3_sync.sh"),
+        allow_single_file = True,
+    ),
+}
+
+def _s3_sync_impl(ctx):
+    executable = ctx.actions.declare_file("{}/s3_sync.sh".format(ctx.label.name))
+    ctx.actions.expand_template(
+        template = ctx.file._sync_script,
+        output = executable,
+        is_executable = True,
+        substitutions = {
+            "$aws": ctx.attr.aws[DefaultInfo].default_runfiles.files.to_list()[0].short_path,
+            "artifacts=()": "artifacts=({})".format(" ".join([s.short_path for s in ctx.files.srcs])),
+            "# Process Arguments": "bucket_file=\"{}\"".format(ctx.file.bucket.short_path),
+        },
+    )
+    return [DefaultInfo(
+        executable = executable,
+        runfiles = ctx.runfiles(files = [executable, ctx.file.bucket] + ctx.files.srcs).merge(ctx.attr.aws[DefaultInfo].default_runfiles),
+    )]
+
+s3_sync = rule(
+    implementation = _s3_sync_impl,
+    executable = True,
+    attrs = _ATTRS,
+    doc = _DOC,
+)

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -199,7 +199,7 @@ if [[ ! -z "${role:-}" && "${dry_run}" == "false" ]]; then
     msg "Assuming role '${role}' before sync"
     # shellcheck disable=SC2183,SC2046
     export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" \
-        $("$aws" sts assume-role --role-arn "${role}" --role-session-name S3Releaser --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
+        $("$aws" sts assume-role --role-arn "${role}" --role-session-name S3Sync --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
 
 fi
 

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 Aspect Build Systems, Inc.
+#
+# s3 cp/sync script intended for use with s3_sync rule
+
+set -o errexit -o nounset -o pipefail
+
+# Functions
+
+msg() {
+    if [[ $# -gt 0 ]]; then
+        local msg="${1:-}"
+        shift 1
+        while (("$#")); do
+            msg="${msg:-}"$'\n'"${1}"
+            shift 1
+        done
+        echo "${msg}"
+    else
+        cat
+    fi
+}
+
+warn() {
+    if [[ $# -gt 0 ]]; then
+        local msg="${1:-}"
+        shift 1
+        while (("$#")); do
+            msg="${msg:-}"$'\n'"${1}"
+            shift 1
+        done
+        echo >&2 "${msg}"
+    else
+        cat >&2
+    fi
+}
+
+# Echos the provided message to stderr and exits with an error (1).
+# shellcheck disable=SC2120
+fail() {
+    warn "$@"
+    exit 1
+}
+
+# Print an error message and dump the usage/help for the utility.
+# This function expects a get_usage function to be defined.
+usage_error() {
+    local msg="${1:-}"
+    cmd=(fail)
+    [[ -z "${msg:-}" ]] || cmd+=("${msg}" "")
+    cmd+=("$(get_usage)")
+    "${cmd[@]}"
+}
+
+show_usage() {
+    get_usage
+    exit 0
+}
+
+get_usage() {
+    local utility
+    utility="$(basename "${BASH_SOURCE[0]}")"
+    cat <<-'EOF'
+Copies the specified artifacts to an S3 bucket.
+
+Usage:
+EOF
+    echo "${utility} [OPTION]... <artifact>..."
+    cat <<-'EOF'
+Options:
+  --bucket                The name of the S3 bucket.
+  --bucket_file <file>    The path to a file that contains the name of the S3 bucket.
+  --[no]dry_run           Toggles whether the utility will run in dry-run mode.
+                          Default: false
+  --sync_archive          Rather than copy an archive file, unpack it and sync the contents.
+
+Arguments:
+  <artifact>              The path to a file which will be copied to the S3 bucket.
+                          One or more artifacts can be specified.
+EOF
+}
+
+cp_artifact() {
+    local artifact="${1}"
+    local bucket="${2}"
+
+    if [ -d "${artifact}" ]; then
+        # Always flatten directories
+        for f in "${artifact}"/*; do
+            cp_artifact "${f}" "${bucket}"
+        done
+    elif [[ "${sync_archive:-}" ]]; then
+        if [[ "${dry_run}" == "false" ]]; then
+            warn "Syncing ${artifact} to ${bucket}"
+            local untar
+            untar=$(mktemp -d)
+            tar -xf "${artifact}" -C "${untar}"
+            # shellcheck disable=SC2154
+            "$aws" s3 sync "${untar}" "${bucket}"
+        else
+            warn "[DRY RUN] Would sync ${artifact} to ${bucket}"
+        fi
+    else
+        local dst
+        dst="${bucket}/$(basename "${artifact}")"
+        if [[ "${dry_run}" == "false" ]]; then
+            warn "Copying ${artifact} to ${dst}"
+            "$aws" s3 cp "${artifact}" "${dst}"
+        else
+            warn "[DRY RUN] Would copy ${artifact} to ${dst}"
+        fi
+    fi
+}
+
+# Collect Args
+
+dry_run=false
+artifacts=()
+
+while (("$#")); do
+    case "${1}" in
+    "--help")
+        show_usage
+        ;;
+    "--bucket")
+        bucket="${2}"
+        shift 2
+        ;;
+    "--bucket_file")
+        bucket_file="${2}"
+        shift 2
+        ;;
+    "--dry_run")
+        dry_run="true"
+        shift 1
+        ;;
+    "--nodry_run")
+        dry_run="false"
+        shift 1
+        ;;
+    "--sync_archive")
+        sync_archive="true"
+        shift 1
+        ;;
+    "--role")
+        role="${2}"
+        shift 2
+        ;;
+    "--profile")
+        export AWS_PROFILE="${2}"
+        shift 2
+        ;;
+    --*)
+        usage_error "Unrecognized flag. ${1}"
+        ;;
+    *)
+        artifacts+=("${1}")
+        shift 1
+        ;;
+    esac
+done
+
+# Process Arguments
+
+[[ -n "${bucket_file:-}" ]] && bucket="$(<"${bucket_file}")"
+
+[[ -n "${bucket:-}" ]] || usage_error "Missing value for 'bucket'."
+
+protocol="s3"
+
+[[ "${bucket}" =~ ^${protocol}:// ]] || bucket="${protocol}://${bucket}"
+
+[[ ${#artifacts[@]} -gt 0 ]] || usage_error "No artifacts were specified."
+
+[[ "${dry_run}" == "true" ]] &&
+    warn <<-'EOF'
+This is a dry run. No artifacts will be copied.  To copy artifacts, run
+with '--nodry_run'.
+  bazel run --config=release //path/to/this:tool -- --nodry_run
+
+EOF
+
+# Check for Pre-requisites
+
+# FIXME: doesn't work with SSO?
+# if [[ "${dry_run}" == "false" ]]; then
+#     # Ensure that the user's auth works
+
+#     # shellcheck disable=SC2119
+#     "$aws" sts get-caller-identity >/dev/null 2>&1 || fail <<-'EOF'
+# It appears that your aws credentials are not configured properly. Please run
+# 'aws configure' and try again.
+# EOF
+# fi
+
+# shellcheck disable=SC2236
+if [[ ! -z "${role:-}" && "${dry_run}" == "false" ]]; then
+    msg "Assuming role '${role}' before sync"
+    # shellcheck disable=SC2183,SC2046
+    export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" \
+        $("$aws" sts assume-role --role-arn "${role}" --role-session-name S3Releaser --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
+
+fi
+
+# Copy artifacts
+
+msg "Copying the following artifacts to ${bucket}:" "${artifacts[@]}" ""
+
+for artifact in "${artifacts[@]}"; do
+    cp_artifact "${artifact}" "${bucket}"
+done
+
+# shellcheck disable=SC2236
+if [[ ! -z "${role:-}" && "${dry_run}" == "false" ]]; then
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_SESSION_TOKEN
+fi

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,6 +2,30 @@
 
 Public API re-exports
 
+<a id="s3_sync"></a>
+
+## s3_sync
+
+<pre>
+s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-srcs">srcs</a>)
+</pre>
+
+Executable rule to copy or sync files to an S3 bucket.
+
+Intended for use with `bazel run`, and with Aspect's Continuous Delivery feature.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="s3_sync-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="s3_sync-aws"></a>aws |  AWS CLI   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>@aws//:aws</code> |
+| <a id="s3_sync-bucket"></a>bucket |  file containing a single line: the S3 bucket to copy to   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="s3_sync-srcs"></a>srcs |  Files to copy to the s3 bucket   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+
+
 <a id="aws_py_lambda"></a>
 
 ## aws_py_lambda

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -7,7 +7,7 @@ Public API re-exports
 ## s3_sync
 
 <pre>
-s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-srcs">srcs</a>)
+s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-role">role</a>, <a href="#s3_sync-srcs">srcs</a>)
 </pre>
 
 Executable rule to copy or sync files to an S3 bucket.
@@ -23,6 +23,7 @@ Intended for use with `bazel run`, and with Aspect's Continuous Delivery feature
 | <a id="s3_sync-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="s3_sync-aws"></a>aws |  AWS CLI   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>@aws//:aws</code> |
 | <a id="s3_sync-bucket"></a>bucket |  file containing a single line: the S3 bucket to copy to   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="s3_sync-role"></a>role |  Assume this role before copying files, using <code>aws sts assume-role</code>   | String | optional | <code>""</code> |
 | <a id="s3_sync-srcs"></a>srcs |  Files to copy to the s3 bucket   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 
 

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -16,8 +16,11 @@ expand_template(
 # Example usages:
 # Dry run: show what files would be copied
 #  bazel run //examples/release_to_s3 -- --dry_run
+# Use a different profile:
+#  bazel run //examples/release_to_s3 -- --profile=prod
 s3_sync(
     name = "release_to_s3",
     srcs = ["my_file.txt"],
     bucket = ":release_bucket",
+    role = "arn:aws:iam::250292866473:role/AspectEngineering",
 )

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
+load("@aspect_rules_aws//aws:defs.bzl", "s3_sync")
+
+# Allow the destination bucket to vary depending on the stamp information
+expand_template(
+    name = "release_bucket",
+    out = "bucket.txt",
+    # as an example, use the --embed_label flag to choose a destination bucket, e.g.
+    # bazel run --stamp --embed_label=prod123 //my:s3_sync
+    # will sync to myorg-prod123-bucket
+    stamp_substitutions = {"dev": "{{BUILD_EMBED_LABEL}}"},
+    # unstamped builds will release to the "dev" bucket
+    template = ["myorg-dev-bucket"],
+)
+
+# Example usages:
+# Dry run: show what files would be copied
+#  bazel run //examples/release_to_s3 -- --dry_run
+s3_sync(
+    name = "release_to_s3",
+    srcs = ["my_file.txt"],
+    bucket = ":release_bucket",
+)

--- a/examples/release_to_s3/my_file.txt
+++ b/examples/release_to_s3/my_file.txt
@@ -1,0 +1,1 @@
+Placeholder for some content you can ship to an S3 bucket.


### PR DESCRIPTION
---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

New `s3_sync` executable rule allows artifacts to be released to an S3 bucket.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

`bazel run --stamp --embed_label=alexeagle-test examples/release_to_s3 -- --profile AspectAdministration-250292866473`
resulted in a file in the expected bucket.