### PR TITLE
feat: Add prefix attribute to s3_sync rule

### DIFF
--- a/aws/private/s3_sync.bzl
+++ b/aws/private/s3_sync.bzl
@@ -17,7 +17,7 @@ _ATTRS = {
         allow_single_file = True,
         mandatory = True,
     ),
-    "prefix": attr.string(
+    "prefix": attr.label(
         doc = "file containting a single line: Prefix to prepend to artifact names when copying to S3",
         allow_single_file = True,
         mandatory = False,
@@ -38,8 +38,8 @@ _ATTRS = {
 def _s3_sync_impl(ctx):
     executable = ctx.actions.declare_file("{}/s3_sync.sh".format(ctx.label.name))
     vars = ["bucket_file=\"{}\"".format(ctx.file.bucket.short_path)]
-    if ctx.attr.prefix:
-        vars.append("prefix_file=\"{}\"".format(ctx.attr.prefix))
+    if ctx.file.prefix:
+        vars.append("prefix_file=\"{}\"".format(ctx.file.prefix.short_path))
     if ctx.attr.role:
         vars.append("role=\"{}\"".format(ctx.attr.role))
     ctx.actions.expand_template(
@@ -54,7 +54,7 @@ def _s3_sync_impl(ctx):
     )
     return [DefaultInfo(
         executable = executable,
-        runfiles = ctx.runfiles(files = [executable, ctx.file.bucket] + ctx.files.srcs).merge(ctx.attr.aws[DefaultInfo].default_runfiles),
+        runfiles = ctx.runfiles(files = [executable, ctx.file.bucket] + ([ctx.file.prefix] if ctx.file.prefix else []) + ctx.files.srcs).merge(ctx.attr.aws[DefaultInfo].default_runfiles),
     )]
 
 s3_sync = rule(

--- a/aws/private/s3_sync.bzl
+++ b/aws/private/s3_sync.bzl
@@ -17,6 +17,11 @@ _ATTRS = {
         allow_single_file = True,
         mandatory = True,
     ),
+    "prefix": attr.string(
+        doc = "Prefix to prepend to artifact names when copying to S3",
+        default = "",
+        mandatory = False,
+    ),
     "role": attr.string(
         doc = "Assume this role before copying files, using `aws sts assume-role`",
     ),
@@ -32,7 +37,10 @@ _ATTRS = {
 
 def _s3_sync_impl(ctx):
     executable = ctx.actions.declare_file("{}/s3_sync.sh".format(ctx.label.name))
-    vars = ["bucket_file=\"{}\"".format(ctx.file.bucket.short_path)]
+    vars = [
+        "bucket_file=\"{}\"".format(ctx.file.bucket.short_path),
+        "prefix=\"{}\"".format(ctx.attr.prefix),
+    ]
     if ctx.attr.role:
         vars.append("role=\"{}\"".format(ctx.attr.role))
     ctx.actions.expand_template(

--- a/aws/private/s3_sync.bzl
+++ b/aws/private/s3_sync.bzl
@@ -18,8 +18,8 @@ _ATTRS = {
         mandatory = True,
     ),
     "prefix": attr.string(
-        doc = "Prefix to prepend to artifact names when copying to S3",
-        default = "",
+        doc = "file containting a single line: Prefix to prepend to artifact names when copying to S3",
+        allow_single_file = True,
         mandatory = False,
     ),
     "role": attr.string(
@@ -37,10 +37,9 @@ _ATTRS = {
 
 def _s3_sync_impl(ctx):
     executable = ctx.actions.declare_file("{}/s3_sync.sh".format(ctx.label.name))
-    vars = [
-        "bucket_file=\"{}\"".format(ctx.file.bucket.short_path),
-        "prefix=\"{}\"".format(ctx.attr.prefix),
-    ]
+    vars = ["bucket_file=\"{}\"".format(ctx.file.bucket.short_path)]
+    if ctx.attr.prefix:
+        vars.append("prefix_file=\"{}\"".format(ctx.attr.prefix))
     if ctx.attr.role:
         vars.append("role=\"{}\"".format(ctx.attr.role))
     ctx.actions.expand_template(

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -72,9 +72,10 @@ EOF
 Options:
   --bucket                The name of the S3 bucket.
   --bucket_file <file>    The path to a file that contains the name of the S3 bucket.
+  --prefix <prefix>       Prefix to prepend to artifact names when copying to S3.
+  --prefix_file <prefix>  The path to a file that contains the prefix to prepend to artifact names when copying to S3.
   --[no]dry_run           Toggles whether the utility will run in dry-run mode.
                           Default: false
-  --prefix <prefix>       Prefix to prepend to artifact names when copying to S3.
 
 Arguments:
   <artifact>              The path to a file which will be copied to the S3 bucket.
@@ -145,6 +146,10 @@ while (("$#")); do
         prefix="${2}"
         shift 2
         ;;
+    "--prefix_file")
+        prefix_file="${2}"
+        shift 2
+        ;;
     --*)
         usage_error "Unrecognized flag. ${1}"
         ;;
@@ -160,6 +165,10 @@ done
 [[ -n "${bucket_file:-}" ]] && bucket="$(<"${bucket_file}")"
 
 [[ -n "${bucket:-}" ]] || usage_error "Missing value for 'bucket'."
+
+[[ -n "${prefix_file:-}" ]] && prefix="$(<"${prefix_file}")"
+
+[[ -n "${prefix:-}" ]] || usage_error "Missing value for 'prefix'."
 
 protocol="s3"
 

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -72,8 +72,8 @@ EOF
 Options:
   --bucket                The name of the S3 bucket.
   --bucket_file <file>    The path to a file that contains the name of the S3 bucket.
-  --prefix <prefix>       Prefix to prepend to artifact names when copying to S3.
-  --prefix_file <prefix>  The path to a file that contains the prefix to prepend to artifact names when copying to S3.
+  --prefix                Prefix to prepend to artifact names when copying to S3.
+  --prefix_file <file>    The path to a file that contains the prefix to prepend to artifact names when copying to S3.
   --[no]dry_run           Toggles whether the utility will run in dry-run mode.
                           Default: false
 

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -95,9 +95,7 @@ cp_artifact() {
         done
     else
         local dst
-        local filename
-        filename=$(basename "${artifact}")
-        dst="${bucket}/${prefix}${filename}"
+        dst="${bucket}/${prefix}$(basename "${artifact}")"
         if [[ "${dry_run}" == "false" ]]; then
             warn "Copying ${artifact} to ${dst}"
             "$aws" s3 cp "${artifact}" "${dst}"

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -168,8 +168,6 @@ done
 
 [[ -n "${prefix_file:-}" ]] && prefix="$(<"${prefix_file}")"
 
-[[ -n "${prefix:-}" ]] || usage_error "Missing value for 'prefix'."
-
 protocol="s3"
 
 [[ "${bucket}" =~ ^${protocol}:// ]] || bucket="${protocol}://${bucket}"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -23,6 +23,7 @@ Intended for use with `bazel run`, and with Aspect's Continuous Delivery feature
 | <a id="s3_sync-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="s3_sync-aws"></a>aws |  AWS CLI   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>@aws//:aws</code> |
 | <a id="s3_sync-bucket"></a>bucket |  file containing a single line: the S3 bucket to copy to   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="s3_sync-prefix"></a>prefix |  file containing a single line: Prefix to prepend to artifact names when copying to S3   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  |
 | <a id="s3_sync-role"></a>role |  Assume this role before copying files, using <code>aws sts assume-role</code>   | String | optional | <code>""</code> |
 | <a id="s3_sync-srcs"></a>srcs |  Files to copy to the s3 bucket   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -13,6 +13,18 @@ expand_template(
     template = ["myorg-dev-bucket"],
 )
 
+# Allow the destination prefix to vary depending on the stamp information
+expand_template(
+    name = "release_prefix",
+    out = "prefix.txt",
+    # as an example, use if you have the STABLE_RELEASE_PREFIX value being generated to a value of "prod789" in your workspace status script, then
+    # bazel run --stamp //my:s3_sync
+    # will sync to prefix-prod789/ prefix
+    stamp_substitutions = {"dev": "{{STABLE_RELEASE_PREFIX}}"},
+    # unstamped builds will release to the "prefix-dev" prefix
+    template = ["prefix-dev/"],
+)
+
 # Example usages:
 # Dry run: show what files would be copied
 #  bazel run //examples/release_to_s3 -- --dry_run
@@ -22,5 +34,6 @@ s3_sync(
     name = "release_to_s3",
     srcs = ["my_file.txt"],
     bucket = ":release_bucket",
+    prefix = ":release_prefix",
     role = "arn:aws:iam::250292866473:role/AspectEngineering",
 )


### PR DESCRIPTION
---

<!-- Delete this comment! 
Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md 
PR title and description must comply with https://www.conventionalcommits.org/
-->

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add option `prefix` to `s3_sync` rule to copy files to a specific prefix in the bucket.

### Test plan

<!-- Delete any which do not apply -->

- Manual testing; please provide instructions so we can reproduce:

`bazel run examples/release_to_s3`
resulted in a file in the expected bucket. Note: While testing, updated the bucket name in examples/release_to_s3/BUILD to a bucket where I have access.