### PR TITLE
feat(s3_sync): allow string for bucket in addition to file

### DIFF
--- a/aws/private/s3_sync.bzl
+++ b/aws/private/s3_sync.bzl
@@ -12,10 +12,12 @@ _ATTRS = {
         allow_files = True,
         mandatory = True,
     ),
-    "bucket": attr.label(
-        doc = "file containing a single line: the S3 bucket to copy to",
+    "bucket": attr.string(
+        doc = "S3 path to copy to",
+    ),
+    "bucket_file": attr.label(
+        doc = "file containing a single line: the S3 path to copy to. Useful because the file content may be stamped.",
         allow_single_file = True,
-        mandatory = True,
     ),
     "role": attr.string(
         doc = "Assume this role before copying files, using `aws sts assume-role`",
@@ -32,7 +34,17 @@ _ATTRS = {
 
 def _s3_sync_impl(ctx):
     executable = ctx.actions.declare_file("{}/s3_sync.sh".format(ctx.label.name))
-    vars = ["bucket_file=\"{}\"".format(ctx.file.bucket.short_path)]
+    runfiles = [executable] + ctx.files.srcs
+    vars = []
+    if not ctx.attr.bucket and not ctx.attr.bucket_file:
+        fail("Either 'bucket' or 'bucket_file' must be set")
+    if ctx.attr.bucket and ctx.attr.bucket_file:
+        fail("At most one of 'bucket' or 'bucket_file' may be set")
+    if ctx.attr.bucket_file:
+        vars.append("bucket_file=\"{}\"".format(ctx.file.bucket_file.short_path))
+        runfiles.append(ctx.file.bucket_file)
+    else:
+        vars.append("bucket=\"{}\"".format(ctx.attr.bucket))
     if ctx.attr.role:
         vars.append("role=\"{}\"".format(ctx.attr.role))
     ctx.actions.expand_template(
@@ -45,9 +57,10 @@ def _s3_sync_impl(ctx):
             "# Collect Args": "\n".join(vars),
         },
     )
+
     return [DefaultInfo(
         executable = executable,
-        runfiles = ctx.runfiles(files = [executable, ctx.file.bucket] + ctx.files.srcs).merge(ctx.attr.aws[DefaultInfo].default_runfiles),
+        runfiles = ctx.runfiles(files = runfiles).merge(ctx.attr.aws[DefaultInfo].default_runfiles),
     )]
 
 s3_sync = rule(

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -7,7 +7,7 @@ Public API re-exports
 ## s3_sync
 
 <pre>
-s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-role">role</a>, <a href="#s3_sync-srcs">srcs</a>)
+s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-bucket_file">bucket_file</a>, <a href="#s3_sync-role">role</a>, <a href="#s3_sync-srcs">srcs</a>)
 </pre>
 
 Executable rule to copy or sync files to an S3 bucket.
@@ -22,7 +22,8 @@ Intended for use with `bazel run`, and with Aspect's Continuous Delivery feature
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="s3_sync-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="s3_sync-aws"></a>aws |  AWS CLI   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>@aws//:aws</code> |
-| <a id="s3_sync-bucket"></a>bucket |  file containing a single line: the S3 bucket to copy to   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="s3_sync-bucket"></a>bucket |  S3 path to copy to   | String | optional | <code>""</code> |
+| <a id="s3_sync-bucket_file"></a>bucket_file |  file containing a single line: the S3 path to copy to. Useful because the file content may be stamped.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="s3_sync-role"></a>role |  Assume this role before copying files, using <code>aws sts assume-role</code>   | String | optional | <code>""</code> |
 | <a id="s3_sync-srcs"></a>srcs |  Files to copy to the s3 bucket   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -3,14 +3,14 @@ load("@aspect_rules_aws//aws:defs.bzl", "s3_sync")
 
 # Allow the destination bucket to vary depending on the stamp information
 expand_template(
-    name = "release_bucket",
+    name = "release_destination",
     out = "bucket.txt",
     # as an example, use the --embed_label flag to choose a destination bucket, e.g.
     # bazel run --stamp --embed_label=prod123 //my:s3_sync
-    # will sync to myorg-prod123-bucket
+    # will sync to myorg-prod123-bucket/nested/path
     stamp_substitutions = {"dev": "{{BUILD_EMBED_LABEL}}"},
-    # unstamped builds will release to the "dev" bucket
-    template = ["myorg-dev-bucket"],
+    # unstamped builds will release nested/path/* in the "dev" bucket
+    template = ["myorg-dev-bucket/nested/path"],
 )
 
 # Example usages:
@@ -21,6 +21,12 @@ expand_template(
 s3_sync(
     name = "release_to_s3",
     srcs = ["my_file.txt"],
-    bucket = ":release_bucket",
+    bucket_file = ":release_destination",
     role = "arn:aws:iam::250292866473:role/AspectEngineering",
+)
+
+s3_sync(
+    name = "release_to_fixed_path",
+    srcs = ["my_file.txt"],
+    bucket = "my-bucket-name/sub-folder",
 )


### PR DESCRIPTION
Also clarify in examples that the bucket attribute accepts any S3 path


---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes - but the `bucket` attribute was just released yesterday
- Suggested release notes appear below: yes

s3_push#bucket is now a literal string. Use the `bucket_file` to read the bucket from a file.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Ran the two example targets