### PR TITLE
fix: compat with Bazel 5

### DIFF
--- a/aws/repositories.bzl
+++ b/aws/repositories.bzl
@@ -156,6 +156,9 @@ aws_repositories = repository_rule(
     attrs = _ATTRS,
 )
 
+def _is_bazel_6_or_greater():
+    return "apple_binary" not in dir(native)
+
 def _aws_alias_impl(rctx):
     rctx.file("BUILD.bazel", """\
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
@@ -164,16 +167,16 @@ native_binary(
     name = "aws",
     src = select(
         {{
-            "@bazel_tools//src/conditions:linux_x86_64": "@@{0}_linux-x86_64//:aws",
-            "@bazel_tools//src/conditions:linux_aarch64": "@@{0}_linux-aarch64//:aws",
-            "@bazel_tools//src/conditions:darwin_x86_64": "@@{0}_darwin//:aws",
-            "@bazel_tools//src/conditions:darwin_arm64": "@@{0}_darwin//:aws",
+            "@bazel_tools//src/conditions:linux_x86_64": "{0}_linux-x86_64//:aws",
+            "@bazel_tools//src/conditions:linux_aarch64": "{0}_linux-aarch64//:aws",
+            "@bazel_tools//src/conditions:darwin_x86_64": "{0}_darwin//:aws",
+            "@bazel_tools//src/conditions:darwin_arm64": "{0}_darwin//:aws",
         }},
     ),
     out = "aws",
     visibility = ["//visibility:public"],
 )
-""".format(rctx.name))
+""".format(("@@" if _is_bazel_6_or_greater() else "@") + rctx.name))
 
 aws_alias = repository_rule(
     _aws_alias_impl,


### PR DESCRIPTION
The @@ syntax for canonical repo name did not exist


---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```
alex@a:~/Projects/rules_aws/e2e/smoke$ USE_BAZEL_VERSION=5.4.0 bazel run @aws//:aws
```

Verified that command fails without this fix.