### PR TITLE
feat: allow s3 file to be copied to specific URI

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,8 @@ module(
 
 # Lower-bound dependency versions.
 # Do not change unless the rules no longer work with the current version.
-bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
+# Needed for #804 Use statically-linked bsdtar on all platforms
+bazel_dep(name = "aspect_bazel_lib", version = "2.6.1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_oci", version = "1.7.4")

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -7,7 +7,7 @@ Public API re-exports
 ## s3_sync
 
 <pre>
-s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-bucket_file">bucket_file</a>, <a href="#s3_sync-role">role</a>, <a href="#s3_sync-srcs">srcs</a>)
+s3_sync(<a href="#s3_sync-name">name</a>, <a href="#s3_sync-aws">aws</a>, <a href="#s3_sync-bucket">bucket</a>, <a href="#s3_sync-bucket_file">bucket_file</a>, <a href="#s3_sync-destination_uri_file">destination_uri_file</a>, <a href="#s3_sync-role">role</a>, <a href="#s3_sync-srcs">srcs</a>)
 </pre>
 
 Executable rule to copy or sync files to an S3 bucket.
@@ -24,6 +24,7 @@ Intended for use with `bazel run`, and with Aspect's Continuous Delivery feature
 | <a id="s3_sync-aws"></a>aws |  AWS CLI   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>@aws//:aws</code> |
 | <a id="s3_sync-bucket"></a>bucket |  S3 path to copy to   | String | optional | <code>""</code> |
 | <a id="s3_sync-bucket_file"></a>bucket_file |  file containing a single line: the S3 path to copy to. Useful because the file content may be stamped.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="s3_sync-destination_uri_file"></a>destination_uri_file |  Only permitted when copying a single src file. A file containing a single line:             the full [S3Uri](https://docs.aws.amazon.com/cli/latest/reference/s3/#path-argument-type) to copy the file to.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="s3_sync-role"></a>role |  Assume this role before copying files, using <code>aws sts assume-role</code>   | String | optional | <code>""</code> |
 | <a id="s3_sync-srcs"></a>srcs |  Files to copy to the s3 bucket   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -30,3 +30,25 @@ s3_sync(
     srcs = ["my_file.txt"],
     bucket = "my-bucket-name/sub-folder",
 )
+
+##############
+# Use case: Copy one file to an exact S3 URI that varies depending on stamping
+# See https://github.com/aspect-build/rules_aws/issues/83
+destination_uri_file = "dst.txt"
+
+expand_template(
+    name = "destination_uri_file",
+    out = destination_uri_file,
+    # as an example, use the --embed_label flag to choose a destination file, e.g.
+    # bazel run --stamp --embed_label=prod123 //my:s3_sync
+    # will sync my_file.txt to myorg-bucket/prod123.txt
+    stamp_substitutions = {"default": "{{BUILD_EMBED_LABEL}}"},
+    # unstamped builds will release my_file.txt to myorg-bucket/default.txt
+    template = ["s3://myorg-bucket/default.txt"],
+)
+
+s3_sync(
+    name = "release_to_stamped_filename",
+    srcs = ["my_file.txt"],
+    destination_uri_file = destination_uri_file,
+)


### PR DESCRIPTION
Our current logic always forces files to be copied to the same basename as they appeared in the source tree.

Fixes #83
