### PR TITLE
chore: add a smoke test usage of s3_sync

### DIFF
--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -3,15 +3,17 @@ Add a basic smoke-test target below.
 """
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-# load("aspect_rules_aws//aws:defs.bzl", "...")
+load("@aspect_rules_aws//aws:defs.bzl", "s3_sync")
 
-# Replace with a usage of your rule/macro
-filegroup(name = "empty")
+s3_sync(
+    name = "upload_dry_run",
+    srcs = ["BUILD"],
+    bucket = "s3://my-test-bucket/release_destination",
+)
 
 build_test(
     name = "smoke_test",
     targets = [
-        # targets you add above
-        ":empty",
+        ":upload_dry_run",
     ],
 )


### PR DESCRIPTION

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Check that the rules work on MacOS:
```
% bazel run :upload_dry_run
INFO: Analyzed target //:upload_dry_run (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:upload_dry_run up-to-date:
  bazel-bin/upload_dry_run/s3_sync.sh
INFO: Elapsed time: 0.104s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/upload_dry_run/s3_sync.sh
Copying the following artifacts to s3://my-test-bucket/release_destination:
BUILD

Copying BUILD to s3://my-test-bucket/release_destination/BUILD
upload failed: ./BUILD to s3://my-test-bucket/release_destination/BUILD An error occurred (InvalidAccessKeyId) when calling the PutObject operation: The AWS Access Key Id you provided does not exist in our records.
```