### PR TITLE
fix: destination_uri_file: unbound variable

### DIFF
--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -159,7 +159,7 @@ done
 
 [[ ${#artifacts[@]} -gt 0 ]] || usage_error "No artifacts were specified."
 
-if [[ ! -z "${destination_uri_file}" ]]; then
+if [[ ! -z "${destination_uri_file:-}" ]]; then
     [[ ${#artifacts[@]} -eq 1 ]] || usage_error "destination_uri_file may be used only with a single artifact to copy"
 else
     [[ -n "${bucket_file:-}" ]] && bucket="$(<"${bucket_file}")"
@@ -204,7 +204,7 @@ fi
 
 # Copy artifacts
 
-if [[ ! -z "${destination_uri_file}" ]]; then
+if [[ ! -z "${destination_uri_file:-}" ]]; then
     s3_cp "${artifacts[0]}" "$(<"${destination_uri_file}")"
 else
     msg "Copying the following artifacts to ${bucket}:" "${artifacts[@]}" ""


### PR DESCRIPTION
Clearly I didn't do enough testing of the last PR landed here. But alas, it's highly experimental and the bar is low.

---

### Changes are visible to end-users: no


### Test plan

- Manual testing; please provide instructions so we can reproduce:

```
% bazel run //examples/release_to_s3 -- --dry_run
INFO: Analyzed target //examples/release_to_s3:release_to_s3 (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/release_to_s3:release_to_s3 up-to-date:
  bazel-bin/examples/release_to_s3/release_to_s3/s3_sync.sh
INFO: Elapsed time: 0.088s, Critical Path: 0.00s
INFO: 2 processes: 2 internal.
INFO: Build completed successfully, 2 total actions
INFO: Running command line: bazel-bin/examples/release_to_s3/release_to_s3/s3_sync.sh --dry_run
This is a dry run. No artifacts will be copied.  To copy artifacts, run
with '--nodry_run'.
  bazel run --config=release //path/to/this:tool -- --nodry_run

Copying the following artifacts to s3://myorg-dev-bucket/nested/path:
examples/release_to_s3/my_file.txt

[DRY RUN] Would copy examples/release_to_s3/my_file.txt to s3://myorg-dev-bucket/nested/path/my_file.txt
```