### PR TITLE
add export_files

### DIFF
--- a/aws/repositories.bzl
+++ b/aws/repositories.bzl
@@ -130,6 +130,8 @@ package(default_visibility=["//visibility:public"])
 
 _SRCS = glob(["{v}/**"])
 
+exports_files(_SRCS)
+
 mtree_spec(
     name = "mtree",
     srcs = _SRCS,


### PR DESCRIPTION
Solves the following error. Cause not known yet. The example targets in this repo work fine, but fail when we use it in our repo.

```
ERROR: /private/var/tmp/_bazel_florian.berchtold/34a4658767e2a39dbc9be98228def1f5/external/aspect_rules_aws~~aws~aws_darwin/BUILD.bazel:4:6:
  in alias rule @@aspect_rules_aws~~aws~aws_darwin//:aws:
  target '@@aspect_rules_aws~~aws~aws_darwin//installed:aws-cli.pkg/Payload/aws-cli/aws'
  is not visible from target 
  '@@aspect_rules_aws~~aws~aws_darwin//:aws'.

Check the visibility declaration of the former target if you think the dependency is legitimate. To set the visibility of that source file target, use the exports_files() function
```

---
