### PR TITLE
Fix run_cli workspace run using bazel 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,4 +41,4 @@ jobs:
         run: bazel run @aws help
       - name: run CLI with workspace
         working-directory: e2e/smoke
-        run: bazel run --noenable_bzlmod @aws help
+        run: bazel run --enable_workspace @aws help


### PR DESCRIPTION
Found this while looking into #91 and main is broken as well.

```
ERROR: Error computing the main repository mapping: error loading package 'external': Both --enable_bzlmod and --enable_workspace are disabled, but one of them must be enabled to fetch external dependencies.
```

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
