### PR TITLE
Fix warning in deps resolution

### DIFF
--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,0 +1,1 @@
+build --check_direct_dependencies=off

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "aspect_rules_aws", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
 
 local_path_override(
     module_name = "aspect_rules_aws",

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "aspect_rules_aws", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
 
 local_path_override(
     module_name = "aspect_rules_aws",


### PR DESCRIPTION
Fixes `WARNING: For repository 'bazel_skylib', the root module requires module version bazel_skylib@1.6.1, but got bazel_skylib@1.7.1 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off`