### PR TITLE
Ensure unique toolchain versions

### DIFF
--- a/aws/extensions.bzl
+++ b/aws/extensions.bzl
@@ -10,6 +10,7 @@ names (the latest version will be picked for each name) and can register them as
 effectively overriding the default named toolchain due to toolchain resolution precedence.
 """
 
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load(":repositories.bzl", "aws_register_toolchains")
 
 _DEFAULT_NAME = "aws"
@@ -35,14 +36,15 @@ def _toolchain_extension(module_ctx):
                 registrations[toolchain.name] = []
             registrations[toolchain.name].append(toolchain.aws_cli_version)
     for name, versions in registrations.items():
-        if len(versions) > 1:
+        unique_versions = sets.to_list(sets.make(versions))
+        if len(unique_versions) > 1:
             # TODO: should be semver-aware, using MVS
-            selected = sorted(versions, reverse = True)[0]
+            selected = sorted(unique_versions, reverse = True)[0]
 
             # buildifier: disable=print
-            print("NOTE: aws toolchain {} has multiple versions {}, selected {}".format(name, versions, selected))
+            print("NOTE: aws toolchain {} has multiple versions {}, selected {}".format(name, unique_versions, selected))
         else:
-            selected = versions[0]
+            selected = unique_versions[0]
 
         aws_register_toolchains(
             name = name,


### PR DESCRIPTION
If registering the default aws toolchain with `2.13.0`, a user gets the warning `NOTE: aws toolchain aws has multiple versions ["2.13.0", "2.13.0"], selected 2.13.0`. With this change, the warning is gone.

Question is, do we want this, or should the user know if they are registering the same toolchain multiple time?

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Call `aws.toolchain(aws_cli_version = "2.13.0")` multiple times in `e2e/smoke/MODULE.bazel`. With this change, you don't see the warning anymore
