### PR TITLE
fix: Add parent dirs to mtree

### DIFF
--- a/aws/private/py_lambda.bzl
+++ b/aws/private/py_lambda.bzl
@@ -46,6 +46,7 @@ def _py_lambda_tar_impl(ctx):
         path = ""
         for dir in ctx.attr.init_files.split("/"):
             path = path + "/" + dir
+            mtree.append(_mtree_line(ctx.attr.prefix + path, type = "dir", mode = "0755"))
             mtree.append(_mtree_line(ctx.attr.prefix + path + "/__init__.py", type = "file"))
 
     mtree.append("")

--- a/aws/private/py_lambda.bzl
+++ b/aws/private/py_lambda.bzl
@@ -1,6 +1,7 @@
 "Rule to produce tar files with py_binary deps and app"
 
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
 
 # Write these two separate layers, so application changes are a small delta when pushing to a registry
 _LAYERS = ["app", "deps"]
@@ -14,6 +15,23 @@ def _short_path(file_):
         second_slash = short_path.index("/", 3)
         short_path = short_path[second_slash + 1:]
     return short_path
+
+
+def _get_mtree_dirs_list_to_file(path):
+    results = []
+    if "/" not in path:
+        return results
+
+    parts = ""
+    for dir_part in path.split("/")[:-1]:
+        if len(parts) == 0:
+            parts += dir_part
+        else:
+            parts += "/" + dir_part
+
+        results.append(_mtree_line(parts, type = "dir", mode = "0755"))
+
+    return results
 
 # Copied from aspect-bazel-lib/lib/private/tar.bzl
 def _mtree_line(file, type, content = None, uid = "0", gid = "0", time = "1672560000", mode = "0644"):
@@ -32,15 +50,17 @@ def _mtree_line(file, type, content = None, uid = "0", gid = "0", time = "167256
 def _py_lambda_tar_impl(ctx):
     deps = ctx.attr.target[DefaultInfo].default_runfiles.files
 
-    # NB: this creates one of the parent directories, but others are implicit
-    mtree = [_mtree_line(ctx.attr.prefix, type = "dir", mode = "0755")]
-
+    mtree = []
     for dep in deps.to_list():
         short_path = _short_path(dep)
+        mtree_path = None
         if dep.owner.workspace_name == "" and ctx.attr.kind == "app":
-            mtree.append(_mtree_line(ctx.attr.prefix + "/" + dep.short_path, type = "file", content = dep.path))
+            mtree_path = ctx.attr.prefix + "/" + dep.short_path
         elif short_path.startswith("site-packages") and ctx.attr.kind == "deps":
-            mtree.append(_mtree_line(ctx.attr.prefix + short_path[len("site-packages"):], type = "file", content = dep.path))
+            mtree_path = ctx.attr.prefix + short_path[len("site-packages"):]
+        if mtree_path:
+            mtree.extend(_get_mtree_dirs_list_to_file(mtree_path))
+            mtree.append(_mtree_line(mtree_path, type = "file", content = dep.path))
 
     if ctx.attr.kind == "app" and ctx.attr.init_files:
         path = ""
@@ -49,6 +69,8 @@ def _py_lambda_tar_impl(ctx):
             mtree.append(_mtree_line(ctx.attr.prefix + path, type = "dir", mode = "0755"))
             mtree.append(_mtree_line(ctx.attr.prefix + path + "/__init__.py", type = "file"))
 
+    mtree = sets.to_list(sets.make(mtree))
+    mtree = sorted(mtree, key = lambda x: len(x.split("/")))
     mtree.append("")
     ctx.actions.write(ctx.outputs.output, "\n".join(mtree))
 


### PR DESCRIPTION
Nested files/folders in image layers result in `InvalidImage(MissingParentDirectory: Parent directory does not exist for file` when deploying on AWS if the parent folders aren't listed in the layer archive mtree.

---

### Changes are visible to end-users: no

### Test plan
- Manually built an image with `aws_py_lambda` with internal and external dependencies, pushed to ECR and deployed on AWS Lambda. Successfully ran code using internal and external dependencies. 
- Successfully built, deploy and tested `//examples/python_lambda:tarball`
![image](https://github.com/user-attachments/assets/fa0826ab-e5a1-457e-9659-fa1d98fd994d)

<!-- Delete any which do not apply -->
- Manual testing; please provide instructions so we can reproduce:
```sh
bazel run //examples/python_lambda:tarball
# Then push, deploy and run the image on AWS Lambda
```
