### PR TITLE
fix: duplicate whitespace in dry run message

### DIFF
--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -174,7 +174,7 @@ fi
 
 [[ "${dry_run}" == "true" ]] &&
     warn <<-'EOF'
-This is a dry run. No artifacts will be copied.  To copy artifacts, run
+This is a dry run. No artifacts will be copied. To copy artifacts, run
 with '--nodry_run'.
   bazel run --config=release //path/to/this:tool -- --nodry_run
 


### PR DESCRIPTION
Just a small fix for a user facing message removing a duplicate whitespace
