### PR TITLE
feat: add `--output_json` to `s3_sync()`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,16 @@ bazel_dep(name = "aspect_rules_py", version = "0.7.3", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
 
+bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+bazel_lib_toolchains.jq()
+bazel_lib_toolchains.coreutils()
+use_repo(bazel_lib_toolchains, "coreutils_toolchains", "jq_toolchains")
+
+register_toolchains(
+    "@jq_toolchains//:all",
+    "@coreutils_toolchains//:all",
+)
+
 aws = use_extension("//aws:extensions.bzl", "aws")
 aws.toolchain(aws_cli_version = "2.13.0")
 use_repo(aws, "aws", "aws_darwin", "aws_linux-aarch64", "aws_linux-x86_64", "aws_toolchains")

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -18,6 +18,8 @@ expand_template(
 #  bazel run //examples/release_to_s3 -- --dry_run
 # Use a different profile:
 #  bazel run //examples/release_to_s3 -- --profile=prod
+# Output a metadata JSON file:
+#  bazel run //examples/release_to_s3 -- --output_json $PWD/out.json
 s3_sync(
     name = "release_to_s3",
     srcs = ["my_file.txt"],


### PR DESCRIPTION
This flag is not meant to be set in a `BUILD.bazel` file, but when `bazel run`ning the target to write out a JSON file containing which files where uploaded where and had which sha256 sum.

This makes in easy for CI jobs uploading artifacts to access that information without having to dig into the bazel output tree.

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

Manually tested with:
- `bazel run //examples/release_to_s3:release_to_s3 -- --dry_run --output_json $PWD/out.json`

Automated testing dependent on https://github.com/aspect-build/rules_aws/pull/89