### PR TITLE
feat: Support args in s3_sync

### DIFF
--- a/aws/private/s3_sync.bzl
+++ b/aws/private/s3_sync.bzl
@@ -27,6 +27,10 @@ _ATTRS = {
     "role": attr.string(
         doc = "Assume this role before copying files, using `aws sts assume-role`",
     ),
+    "s3_args": attr.string_list(
+        doc = "Additional arguments to pass to the aws s3 cp command",
+        default = [],
+    ),
     "aws": attr.label(
         doc = "AWS CLI",
     ),
@@ -74,6 +78,7 @@ def _s3_sync_impl(ctx):
             "$coreutils": coreutils.coreutils_info.bin.short_path,
             "$jq": jq.jqinfo.bin.short_path,
             "artifacts=()": "artifacts=({})".format(" ".join([s.short_path for s in ctx.files.srcs])),
+            "s3_args=()": "s3_args=({})".format(" ".join(ctx.attr.s3_args)),
             "# Collect Args": "\n".join(vars),
         },
     )

--- a/aws/private/s3_sync.sh
+++ b/aws/private/s3_sync.sh
@@ -88,9 +88,12 @@ s3_cp() {
 
     if [[ "${dry_run}" == "false" ]]; then
         warn "Copying ${src} to ${dst}"
-        "$aws" s3 cp "${src}" "${dst}"
+        "$aws" s3 cp "${s3_args[@]}" "${src}" "${dst}"
     else
         warn "[DRY RUN] Would copy ${src} to ${dst}"
+        if [[ "${#s3_args[@]}" -gt 0 ]]; then
+            warn "[DRY RUN] with args: ${s3_args[*]}"
+        fi
     fi
 
     if [[ -n "${output_json_file}" ]]; then
@@ -124,6 +127,7 @@ output_json_results() {
 dry_run=false
 output_json_file=""
 artifacts=()
+s3_args=()
 sha256_results=()
 
 while (("$#")); do

--- a/examples/release_to_s3/BUILD.bazel
+++ b/examples/release_to_s3/BUILD.bazel
@@ -33,6 +33,14 @@ s3_sync(
     bucket = "my-bucket-name/sub-folder",
 )
 
+# s3_args can be used to pass options to aws s3 cp
+s3_sync(
+    name = "release_with_args",
+    srcs = ["my_file.txt"],
+    bucket = "my-bucket-name/sub-folder",
+    s3_args = ["--sse"],
+)
+
 ##############
 # Use case: Copy one file to an exact S3 URI that varies depending on stamping
 # See https://github.com/aspect-build/rules_aws/issues/83


### PR DESCRIPTION
Resolves #100

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing with `--dry_run` and `s3_args = ["--dryrun", "--other-flags"]`
